### PR TITLE
Updating README and RTD examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,15 +35,15 @@ Usage Example
 =============
 
 
-Single Ended
-------------
+MCP3008 Single Ended
+---------------------
 
 .. code-block:: python
 
     import busio
     import digitalio
     import board
-    from adafruit_mcp3xxx.mcp3008 import MCP3008
+    import adafruit_mcp3xxx.mcp3008 as MCP
     from adafruit_mcp3xxx.analog_in import AnalogIn
 
     # create the spi bus
@@ -52,26 +52,26 @@ Single Ended
     # create the cs (chip select)
     cs = digitalio.DigitalInOut(board.D5)
 
-    # create the mcp object from MCP3008 class
-    mcp = MCP3008(spi, cs)
+    # create the mcp object
+    mcp = MCP.MCP3008(spi, cs)
 
     # create an analog input channel on pin 0
-    chan = AnalogIn(mcp, MCP3008.pin_0)
+    chan = AnalogIn(mcp, MCP.P0)
 
     print('Raw ADC Value: ', chan.value)
     print('ADC Voltage: ' + str(chan.voltage) + 'V')
 
 
-Differential
-------------
+MCP3008 Differential
+--------------------
 
 .. code-block:: python
 
     import busio
     import digitalio
     import board
-    from adafruit_mcp3xxx.mcp3008 import MCP3008
-    from adafruit_mcp3xxx.differential_analog_in import DifferentialAnalogIn
+    import adafruit_mcp3xxx.mcp3008 as MCP
+    from adafruit_mcp3xxx.analog_in import AnalogIn
 
     # create the spi bus
     spi = busio.SPI(clock=board.SCK, MISO=board.MISO, MOSI=board.MOSI)
@@ -79,14 +79,67 @@ Differential
     # create the cs (chip select)
     cs = digitalio.DigitalInOut(board.D5)
 
-    # create the mcp object from MCP3008 class
-    mcp = MCP3008(spi, cs)
+    # create the mcp object
+    mcp = MCP.MCP3008(spi, cs)
 
-    # create a differential analog input channel with pin 0 and pin 1
-    chan = DifferentialAnalogIn(mcp, MCP3008.pin_0, MCP3008.pin_1)
+    # create a differential ADC channel between Pin 0 and Pin 1
+    chan = AnalogIn(mcp, MCP.P0, MCP.P1)
 
     print('Differential ADC Value: ', chan.value)
     print('Differential ADC Voltage: ' + str(chan.voltage) + 'V')
+
+MCP3004 Single-Ended
+---------------------
+
+.. code-block:: python
+
+    import busio
+    import digitalio
+    import board
+    import adafruit_mcp3xxx.mcp3004 as MCP
+    from adafruit_mcp3xxx.analog_in import AnalogIn
+
+    # create the spi bus
+    spi = busio.SPI(clock=board.SCK, MISO=board.MISO, MOSI=board.MOSI)
+
+    # create the cs (chip select)
+    cs = digitalio.DigitalInOut(board.D5)
+
+    # create the mcp object
+    mcp = MCP.MCP3004(spi, cs)
+
+    # create an analog input channel on pin 0
+    chan = AnalogIn(mcp, MCP.P0, MCP.P1)
+
+    print('Raw ADC Value: ', chan.value)
+    print('ADC Voltage: ' + str(chan.voltage) + 'V')
+
+MCP3004 Differential
+--------------------
+
+.. code-block:: python
+
+    import busio
+    import digitalio
+    import board
+    import adafruit_mcp3xxx.mcp3004 as MCP
+    from adafruit_mcp3xxx.analog_in import AnalogIn
+
+    # create the spi bus
+    spi = busio.SPI(clock=board.SCK, MISO=board.MISO, MOSI=board.MOSI)
+
+    # create the cs (chip select)
+    cs = digitalio.DigitalInOut(board.D5)
+
+    # create the mcp object
+    mcp = MCP.MCP3004(spi, cs)
+
+    # create a differential ADC channel between Pin 0 and Pin 1
+    chan = AnalogIn(mcp, MCP.P0, MCP.P1)
+
+    print('Differential ADC Value: ', chan.value)
+    print('Differential ADC Voltage: ' + str(chan.voltage) + 'V')
+
 
 
 Contributing

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,14 @@
 API
 ------------
 
-.. automodule:: adafruit_mcp3xxx
+.. automodule:: adafruit_mcp3xxx.adafruit_mcp3xxx
+   :members:
+
+.. automodule:: adafruit_mcp3xxx.adafruit_mcp3004
+   :members:
+
+.. automodule:: adafruit_mcp3xxx.adafruit_mcp3008
+   :members:
+
+.. automodule:: adafruit_mcp3xxx.analog_in
    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,14 +1,5 @@
 API
 ------------
 
-.. automodule:: adafruit_mcp3xxx.adafruit_mcp3xxx
-   :members:
-
-.. automodule:: adafruit_mcp3xxx.adafruit_mcp3004
-   :members:
-
-.. automodule:: adafruit_mcp3xxx.adafruit_mcp3008
-   :members:
-
-.. automodule:: adafruit_mcp3xxx.analog_in
+.. automodule:: adafruit_mcp3xxx
    :members:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,15 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/mcp3008_single_ended_simpletest.py
     :caption: examples/mcp3008_single_ended_simpletest.py
     :linenos:
+
+.. literalinclude:: ../examples/mcp3004_single_ended_simpletest.py
+    :caption: examples/mcp3004_single_ended_simpletest.py
+    :linenos:
+
+.. literalinclude:: ../examples/mcp3008_differential_simpletest.py
+    :caption: mcp3008_differential_simpletest.py
+    :linenos:
+
+.. literalinclude:: ../examples/mcp3004_differential_simpletest.py
+    :caption: mcp3004_differential_simpletest.py
+    :linenos:


### PR DESCRIPTION
- README examples updated to reflect current `examples/`. Added MCP3004 examples.
- Added MCP3008 differential example, 2x mcp3004 examples to RTD

**Addressing** https://github.com/adafruit/Adafruit_CircuitPython_MCP3xxx/issues/9